### PR TITLE
0.3.5 update element names in inventory formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spaghet_kotd_app",
-  "version": "0.2.8",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spaghet_kotd_app",
-      "version": "0.2.8",
+      "version": "0.3.5",
       "dependencies": {
         "@emotion/react": "^11.13.3",
         "@emotion/styled": "^11.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spaghet_kotd_app",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.13.3",

--- a/src/components/inventory-formatter.js
+++ b/src/components/inventory-formatter.js
@@ -30,29 +30,29 @@ const InventoryFormmater = ({ playerInventory }) => {
       },
       element: {
         Air: false,
-        Bles: false,
-        Curs: false,
-        Erth: false,
+        Blessed: false,
+        Cursed: false,
+        Earth: false,
         Fire: false,
         Moon: false,
-        Org: false,
+        Organic: false,
         Sun: false,
-        Syn: false,
-        Wtr: false,
+        Synthetic: false,
+        Water: false,
       }
     });
 
     const optionLabels = {
       Air: 'https://cdn.discordapp.com/emojis/1051333997323628564.webp?size=48&quality=lossless',
-      Bles: 'https://cdn.discordapp.com/emojis/1042933454708408350.webp?size=48&quality=lossless',
-      Curs: 'https://cdn.discordapp.com/emojis/1042933519703343304.webp?size=48&quality=lossless',
-      Erth: 'https://cdn.discordapp.com/emojis/1051333985499885648.webp?size=48&quality=lossless',
+      Blessed: 'https://cdn.discordapp.com/emojis/1042933454708408350.webp?size=48&quality=lossless',
+      Cursed: 'https://cdn.discordapp.com/emojis/1042933519703343304.webp?size=48&quality=lossless',
+      Earth: 'https://cdn.discordapp.com/emojis/1051333985499885648.webp?size=48&quality=lossless',
       Fire: 'https://cdn.discordapp.com/emojis/1042933464594391151.webp?size=48&quality=lossless',
       Moon: 'https://cdn.discordapp.com/emojis/1042933456579072040.webp?size=48&quality=lossless',
-      Org: 'https://cdn.discordapp.com/emojis/1042933517727825980.webp?size=48&quality=lossless',
+      Organic: 'https://cdn.discordapp.com/emojis/1042933517727825980.webp?size=48&quality=lossless',
       Sun: 'https://cdn.discordapp.com/emojis/1042933458357461042.webp?size=48&quality=lossless',
-      Syn: 'https://cdn.discordapp.com/emojis/1042933460475592765.webp?size=48&quality=lossless',
-      Wtr: 'https://cdn.discordapp.com/emojis/1042933352770064394.webp?size=48&quality=lossless',
+      Synthetic: 'https://cdn.discordapp.com/emojis/1042933460475592765.webp?size=48&quality=lossless',
+      Water: 'https://cdn.discordapp.com/emojis/1042933352770064394.webp?size=48&quality=lossless',
     };
 
     // const handleSortChange = (event) => {


### PR DESCRIPTION
The filter keys and option labels used abbreviated element names, which did not match the full element names in the inventory table rows. This mismatch caused the filtering logic to fail for these elements, preventing them from being properly filtered in the table.